### PR TITLE
Alterado .htaccess

### DIFF
--- a/ieducar/.htaccess
+++ b/ieducar/.htaccess
@@ -76,7 +76,7 @@ DirectoryIndex index.php index.html index.htm
 #
 # @link http://php.net/configuration.changes
 <IfModule mod_php5.c>
-  php_value memory_limit                32M
+  php_value memory_limit                64M
   php_value error_reporting             1
   php_flag  display_errors              off
   php_flag  magic_quotes_gpc            off


### PR DESCRIPTION
Modificação no valor da variavel php_value memory_limit  de 32M para  64M
Razão: com 32M a emissão de relatórios não estava funcionando direito, pedindo mais recursos da memoria
