### PR TITLE
Melhorias no DOCKERFILE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,10 @@ MAINTAINER Caroline Salib <caroline@portabilis.com.br>
 RUN apt-get -y update \
     && apt-get install -y curl php-curl git-core apache2 libapache2-mod-php php-pgsql php-pear php-mbstring rpl wget \
     && a2enmod rewrite \
-    && apt-get clean
-
-RUN apt-get install -y libreadline6 libreadline6-dev make gcc zlib1g-dev
-
+    && apt-get clean \
+    && apt-get install -y libreadline6 libreadline6-dev make gcc zlib1g-dev \
 # Instala pacotes pear
-RUN pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha
+    && pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha
 
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 CMD a2ensite 000-default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN apt-get -y update \
     software-properties-common
     python-software-properties
     --no-install-recommends \
+    && add-apt-repository -y ppa:openjdk-r/ppa \
+    && apt-get -y update \
+    && apt-get -y install openjdk-7-jdk \
     && a2enmod rewrite \
 # Instala pacotes pear
     && pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha \
@@ -36,10 +39,6 @@ CMD chmod 777 -R /var/www/html/i-educar
 WORKDIR /var/www/html/i-educar
 
 # Instala dependencia relatórios
-    && add-apt-repository -y ppa:openjdk-r/ppa \
-    && apt-get -y update \
-    && apt-get -y install openjdk-7-jdk
-
 CMD update-alternatives --config java
 
 CMD chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ RUN pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 CMD a2ensite 000-default.conf
 
-EXPOSE 80
-
 CMD mkdir /var/www/html/i-educar
 CMD chmod 777 -R /var/www/html/i-educar
 WORKDIR /var/www/html/i-educar
@@ -30,6 +28,8 @@ RUN apt-get install -y software-properties-common python-software-properties \
 CMD update-alternatives --config java
 
 CMD chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/
+
+EXPOSE 80
 
 CMD /usr/sbin/apache2ctl -D FOREGROUND
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,9 @@ COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 COPY ieducar/* /var/www/html/i-educar
 RUN a2ensite 000-default.conf \
 	&& mkdir /var/www/html/i-educar \
-	&& chmod 777 -R /var/www/html/i-educar \
 	&& update-alternatives --config java \
 	&& groupadd -g 1000 -r portabilis \
 	&& useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis
-# Instala dependencia relatórios
-RUN chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/
 EXPOSE 80
 CMD /usr/sbin/apache2ctl -D FOREGROUND
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
+LABEL maintainer Caroline Salib <caroline@portabilis.com.br>
 
-MAINTAINER Caroline Salib <caroline@portabilis.com.br>
 
 RUN apt-get -y update \
 	&& apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN a2ensite 000-default.conf \
     && groupadd -g 1000 -r portabilis \
     && useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis
     
-COPY * /home/portabilis/
+COPY ieducar/ /home/portabilis/
 
 # Instala dependencia relatórios
 RUN chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,44 +3,44 @@ FROM ubuntu:16.04
 MAINTAINER Caroline Salib <caroline@portabilis.com.br>
 
 RUN apt-get -y update \
-    && apt-get install -y \
-    curl \
-    php-curl \
-    git-core \
-    apache2 \
-    libapache2-mod-php \
-    php-pgsql \
-    php-pear \
-    php-mbstring \
-    rpl \
-    wget \
-    libreadline6 \
-    libreadline6-dev \
-    make \
-    gcc \
-    zlib1g-dev \
-    software-properties-common \
-    python-software-properties \
-    --no-install-recommends \
-    && add-apt-repository -y ppa:openjdk-r/ppa \
-    && apt-get -y update \
-    && apt-get -y install openjdk-7-jdk \
-    && a2enmod rewrite \
-# Instala pacotes pear
-    && pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha \
-    && apt-get clean \
-    && apt-get purge --auto-remove -y \
+	&& apt-get install -y \
+	curl \
+	php-curl \
+	git-core \
+	apache2 \
+	libapache2-mod-php \
+	php-pgsql \
+	php-pear \
+	php-mbstring \
+	rpl \
+	wget \
+	libreadline6 \
+	libreadline6-dev \
+	make \
+	gcc \
+	zlib1g-dev \
+	software-properties-common \
+	python-software-properties \
+	--no-install-recommends \
+	&& add-apt-repository -y ppa:openjdk-r/ppa \
+	&& apt-get -y update \
+	&& apt-get -y install openjdk-7-jdk \
+	&& a2enmod rewrite \
+	# Instala pacotes pear
+	&& pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha \
+	&& apt-get clean \
+	&& apt-get purge --auto-remove -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 
 RUN a2ensite 000-default.conf \
-    && mkdir /var/www/html/i-educar \
-    && chmod 777 -R /var/www/html/i-educar \
-    && update-alternatives --config java \
-    && groupadd -g 1000 -r portabilis \
-    && useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis
-    
+	&& mkdir /var/www/html/i-educar \
+	&& chmod 777 -R /var/www/html/i-educar \
+	&& update-alternatives --config java \
+	&& groupadd -g 1000 -r portabilis \
+	&& useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis
+
 COPY ieducar/ /home/portabilis/
 
 # Instala dependencia relatórios

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get -y update \
     libreadline6
     libreadline6-dev
     make gcc
-    zlib1g-dev \
+    zlib1g-dev 
+    --no-install-recommends \
     && a2enmod rewrite \
 # Instala pacotes pear
     && pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ RUN apt-get -y update \
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 COPY . /var/www/html/i-educar
 RUN a2ensite 000-default.conf \
-	&& mkdir /var/www/html/i-educar \
 	&& update-alternatives --config java \
 	&& groupadd -g 1000 -r portabilis \
 	&& useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y update \
     libreadline6-dev
     make gcc
     zlib1g-dev 
-    RUN apt-get install -y software-properties-common python-software-properties \
+    software-properties-common python-software-properties \
     --no-install-recommends \
     && a2enmod rewrite \
 # Instala pacotes pear

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN a2ensite 000-default.conf \
 COPY * /home/portabilis
 
 # Instala dependencia relatórios
-    && chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/
+RUN chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ RUN apt-get -y update \
     && a2enmod rewrite \
 # Instala pacotes pear
     && pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha \
-    && apt-get clean
+    && apt-get clean \
+    && apt-get purge --auto-remove -y \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 CMD a2ensite 000-default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,14 +34,14 @@ RUN apt-get -y update \
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 
 RUN a2ensite 000-default.conf \
-CMD mkdir /var/www/html/i-educar
-CMD chmod 777 -R /var/www/html/i-educar
+    && mkdir /var/www/html/i-educar \
+    && chmod 777 -R /var/www/html/i-educar
+    && update-alternatives --config java
 WORKDIR /var/www/html/i-educar
 
 # Instala dependencia relatórios
-CMD update-alternatives --config java
+    && chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/
 
-CMD chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Caroline Salib <caroline@portabilis.com.br>
 
 RUN apt-get -y update \
     && apt-get install -y curl php-curl git-core apache2 libapache2-mod-php php-pgsql php-pear php-mbstring rpl wget \
-    && a2enmod rewrite \
     && apt-get install -y libreadline6 libreadline6-dev make gcc zlib1g-dev \
+    && a2enmod rewrite \
 # Instala pacotes pear
     && pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha \
     && apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN a2ensite 000-default.conf \
     && groupadd -g 1000 -r portabilis \
     && useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis
     
-COPY * /home/portabilis
+COPY * /home/portabilis/
 
 # Instala dependencia relatórios
 RUN chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,5 @@ RUN a2ensite 000-default.conf \
 # Instala dependencia relatórios
 RUN chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/
 EXPOSE 80
-WORKDIR /var/www/html/i-educar
 CMD /usr/sbin/apache2ctl -D FOREGROUND
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -y update \
     libreadline6-dev
     make gcc
     zlib1g-dev 
+    RUN apt-get install -y software-properties-common python-software-properties \
     --no-install-recommends \
     && a2enmod rewrite \
 # Instala pacotes pear
@@ -34,7 +35,6 @@ CMD chmod 777 -R /var/www/html/i-educar
 WORKDIR /var/www/html/i-educar
 
 # Instala dependencia relatórios
-RUN apt-get install -y software-properties-common python-software-properties \
     && add-apt-repository -y ppa:openjdk-r/ppa \
     && apt-get -y update \
     && apt-get -y install openjdk-7-jdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get -y update \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
+COPY ieducar/* /var/www/html/i-educar
 
 RUN a2ensite 000-default.conf \
 	&& mkdir /var/www/html/i-educar \
@@ -41,7 +42,6 @@ RUN a2ensite 000-default.conf \
 	&& groupadd -g 1000 -r portabilis \
 	&& useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis
 
-COPY ieducar/ /home/portabilis/
 
 # Instala dependencia relatórios
 RUN chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get -y update \
 	&& apt-get purge --auto-remove -y \
 	&& rm -rf /var/lib/apt/lists/*
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
-COPY ieducar/* /var/www/html/i-educar
+COPY . /var/www/html/i-educar
 RUN a2ensite 000-default.conf \
 	&& mkdir /var/www/html/i-educar \
 	&& update-alternatives --config java \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN apt-get -y update \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
-CMD a2ensite 000-default.conf
 
+RUN a2ensite 000-default.conf \
 CMD mkdir /var/www/html/i-educar
 CMD chmod 777 -R /var/www/html/i-educar
 WORKDIR /var/www/html/i-educar

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,13 @@ RUN a2ensite 000-default.conf \
     && mkdir /var/www/html/i-educar \
     && chmod 777 -R /var/www/html/i-educar
     && update-alternatives --config java
-WORKDIR /var/www/html/i-educar
 
 # Instala dependencia relatórios
     && chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/
 
-
 EXPOSE 80
+
+WORKDIR /var/www/html/i-educar
 
 CMD /usr/sbin/apache2ctl -D FOREGROUND
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ RUN a2ensite 000-default.conf \
     && chmod 777 -R /var/www/html/i-educar \
     && update-alternatives --config java \
     && groupadd -g 1000 -r portabilis \
-    && useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis \
+    && useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis
+    
+COPY * /home/portabilis
 
 # Instala dependencia relatórios
     && chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,24 @@ FROM ubuntu:16.04
 MAINTAINER Caroline Salib <caroline@portabilis.com.br>
 
 RUN apt-get -y update \
-    && apt-get install -y 
-    curl
-    php-curl
-    git-core
-    apache2
-    libapache2-mod-php
-    php-pgsql
-    php-pear
-    php-mbstring
-    rpl
-    wget
-    libreadline6
-    libreadline6-dev
-    make gcc
-    zlib1g-dev 
-    software-properties-common
-    python-software-properties
+    && apt-get install -y \
+    curl \
+    php-curl \
+    git-core \
+    apache2 \
+    libapache2-mod-php \
+    php-pgsql \
+    php-pear \
+    php-mbstring \
+    rpl \
+    wget \
+    libreadline6 \
+    libreadline6-dev \
+    make \
+    gcc \
+    zlib1g-dev \
+    software-properties-common \
+    python-software-properties \
     --no-install-recommends \
     && add-apt-repository -y ppa:openjdk-r/ppa \
     && apt-get -y update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN a2ensite 000-default.conf \
     && mkdir /var/www/html/i-educar \
     && chmod 777 -R /var/www/html/i-educar \
     && update-alternatives --config java \
+    && groupadd -g 1000 -r portabilis \
+    && useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis \
 
 # Instala dependencia relatórios
     && chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y libreadline6 libreadline6-dev make gcc zlib1g-dev
 # Instala pacotes pear
 RUN pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha
 
-ADD ieducar.conf /etc/apache2/sites-available/000-default.conf
+COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 CMD a2ensite 000-default.conf
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get -y update \
     libreadline6-dev
     make gcc
     zlib1g-dev 
-    software-properties-common python-software-properties \
+    software-properties-common
+    python-software-properties
     --no-install-recommends \
     && a2enmod rewrite \
 # Instala pacotes pear

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,24 +31,17 @@ RUN apt-get -y update \
 	&& apt-get clean \
 	&& apt-get purge --auto-remove -y \
 	&& rm -rf /var/lib/apt/lists/*
-
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 COPY ieducar/* /var/www/html/i-educar
-
 RUN a2ensite 000-default.conf \
 	&& mkdir /var/www/html/i-educar \
 	&& chmod 777 -R /var/www/html/i-educar \
 	&& update-alternatives --config java \
 	&& groupadd -g 1000 -r portabilis \
 	&& useradd -u 1000 -r -g portabilis portabilis -d /home/portabilis
-
-
 # Instala dependencia relatórios
 RUN chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/
-
 EXPOSE 80
-
 WORKDIR /var/www/html/i-educar
-
 CMD /usr/sbin/apache2ctl -D FOREGROUND
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ MAINTAINER Caroline Salib <caroline@portabilis.com.br>
 RUN apt-get -y update \
     && apt-get install -y curl php-curl git-core apache2 libapache2-mod-php php-pgsql php-pear php-mbstring rpl wget \
     && a2enmod rewrite \
-    && apt-get clean \
     && apt-get install -y libreadline6 libreadline6-dev make gcc zlib1g-dev \
 # Instala pacotes pear
-    && pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha
+    && pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha \
+    && apt-get clean
 
 COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 CMD a2ensite 000-default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,21 @@ FROM ubuntu:16.04
 MAINTAINER Caroline Salib <caroline@portabilis.com.br>
 
 RUN apt-get -y update \
-    && apt-get install -y curl php-curl git-core apache2 libapache2-mod-php php-pgsql php-pear php-mbstring rpl wget libreadline6 libreadline6-dev make gcc zlib1g-dev \
+    && apt-get install -y 
+    curl
+    php-curl
+    git-core
+    apache2
+    libapache2-mod-php
+    php-pgsql
+    php-pear
+    php-mbstring
+    rpl
+    wget
+    libreadline6
+    libreadline6-dev
+    make gcc
+    zlib1g-dev \
     && a2enmod rewrite \
 # Instala pacotes pear
     && pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM ubuntu:16.04
 MAINTAINER Caroline Salib <caroline@portabilis.com.br>
 
 RUN apt-get -y update \
-    && apt-get install -y curl php-curl git-core apache2 libapache2-mod-php php-pgsql php-pear php-mbstring rpl wget \
-    && apt-get install -y libreadline6 libreadline6-dev make gcc zlib1g-dev \
+    && apt-get install -y curl php-curl git-core apache2 libapache2-mod-php php-pgsql php-pear php-mbstring rpl wget libreadline6 libreadline6-dev make gcc zlib1g-dev \
     && a2enmod rewrite \
 # Instala pacotes pear
     && pear install XML_RPC2 Mail Net_SMTP Services_ReCaptcha \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ COPY ieducar.conf /etc/apache2/sites-available/000-default.conf
 
 RUN a2ensite 000-default.conf \
     && mkdir /var/www/html/i-educar \
-    && chmod 777 -R /var/www/html/i-educar
-    && update-alternatives --config java
+    && chmod 777 -R /var/www/html/i-educar \
+    && update-alternatives --config java \
 
 # Instala dependencia relatórios
     && chmod 777 /home/portabilis/ieducar/modules/Reports/ReportSources/


### PR DESCRIPTION
Dockerfile para ambiente de produção

Resumindo até o momento:

- [x] O comando COPY é mais adequado para esta situação, pois não precisa acesso a internet. **Recomendação da documentação docker**
- [x] O comando EXPOSE pode ser o penúltimo comando antes do comando de execução do container
- [x] A unificação do comando RUN.  Comandos RUN não são interativos! Para fazer imagens de ambiente de produção ou testes, em especial para DockerHUB e TRAVIS-CI.org, reunir o máximo possível se for um Dockerfile para desenvolvimento é local desencorajado e sim usar um comando RUN para cada passo serve para economizar tempo. **Recomendação de boas praticas**
- [x] Reorganizado ordem de comandos
- [x] Limpeza do apt
- [x] Apenas um comando CMD. **Recomendação documentação docker**
- [x] WORKDIR DESNECESSÁRIO
- [x] Remover chmod 777
- [x] Código fonte no container

Não implementado:

- Criação de dockerfile para ambiente de desenvolvimento
-  Atualização do JDK
- Utilização do Ubuntu mais atual

Há muitas alterações a serem feitas